### PR TITLE
Sprok parameterization fixes

### DIFF
--- a/cassandra-docker/entrypoint.go
+++ b/cassandra-docker/entrypoint.go
@@ -37,7 +37,6 @@ import (
 const ugid = 1337
 
 type CassandraDockerConfig struct {
-	VolDir         string   // read/write data, should be a volume
 	SrcConfDir     string   // root path for assets to copy to the volume
 	ConfDir        string   // conf directory
 	DataDir        string   // data directory
@@ -59,7 +58,6 @@ type CassandraDockerConfig struct {
 
 func main() {
 	cdc := CassandraDockerConfig{
-		VolDir:           "/data",
 		SrcConfDir:       "/src/conf",
 		ConfDir:          "/data/conf",
 		DataDir:          "/data/data",

--- a/cassandra-docker/entrypoint.go
+++ b/cassandra-docker/entrypoint.go
@@ -329,7 +329,7 @@ func exists(name string) bool {
 func mkdirAll(name string) {
 	err := os.MkdirAll(name, 0755)
 	if err != nil {
-		log.Fatalf("os.MkdirAll('%s') failed: %s\n", name)
+		log.Fatalf("os.MkdirAll('%s') failed: %s\n", name, err)
 	}
 }
 

--- a/cassandra-docker/entrypoint.go
+++ b/cassandra-docker/entrypoint.go
@@ -43,6 +43,7 @@ type CassandraDockerConfig struct {
 	DataDir        string   // data directory
 	CommitLogDir   string   // cl directory
 	LogDir         string   // log directory
+	LibDir         string   // custom classpath directory
 	SavedCachesDir string   // saved_caches directory
 	CqlshDotDir    string   // ~/.cassandra
 	CassandraYaml  string   // conf/cassandra.yaml
@@ -64,6 +65,7 @@ func main() {
 		DataDir:          "/data/data",
 		CommitLogDir:     "/data/commitlog",
 		LogDir:           "/data/log",
+		LibDir:           "/data/lib",
 		SavedCachesDir:   "/data/saved_caches",
 		CqlshDotDir:      "/data/.cassandra",
 		CassandraYaml:    "/data/conf/cassandra.yaml",

--- a/conf/sproks/cassandra-stress.yaml
+++ b/conf/sproks/cassandra-stress.yaml
@@ -1,11 +1,11 @@
-chdir: /data
+chdir: {{ .DataDir }}
 uid: 1337
 gid: 1337
 argv:
   - /usr/bin/java
   - -Dlogback.configurationFile=logback-tools.xml
   - -cp
-  - {{ glob ":" "/data/conf" "/data/lib" "/opt/cassandra/lib/*.jar" "/opt/cassandra/tools/lib/*.jar" }}
+  - {{ glob ":" .ConfDir .LibDir "/opt/cassandra/lib/*.jar" }}
   - org.apache.cassandra.stress.Stress
 {{ range .ExtraArgs }}  - {{ . }}
 {{ end }}

--- a/conf/sproks/cassandra.yaml
+++ b/conf/sproks/cassandra.yaml
@@ -1,4 +1,4 @@
-chdir: /data
+chdir: {{ .DataDir }}
 stdin: /dev/null
 stdout: /data/log/console.log
 stderr: /data/log/console.log
@@ -25,7 +25,7 @@ argv:
   - -XX:CMSInitiatingOccupancyFraction=75
   - -XX:+UseCMSInitiatingOccupancyOnly
   - -XX:+UseTLAB
-  - -XX:CompileCommandFile=/data/conf/hotspot_compiler
+  - -XX:CompileCommandFile={{ .ConfDir }}/hotspot_compiler
   - -XX:CMSWaitDuration=10000
   - -XX:+UseCondCardMark
   - -Djava.net.preferIPv4Stack=true
@@ -34,10 +34,10 @@ argv:
   - -Dcom.sun.management.jmxremote.ssl=false
   - -Dcom.sun.management.jmxremote.authenticate=false
   - -Dlogback.configurationFile=logback.xml
-  - -Dcassandra.logdir=/data/log
+  - -Dcassandra.logdir={{ .LogDir }}
   - -Dcassandra-foreground=yes
   - -cp
-  - {{ glob ":" "/data/conf" "/data/lib" "/opt/cassandra/lib/*.jar" }}
+  - {{ glob ":" .ConfDir .LibDir "/opt/cassandra/lib/*.jar" }}
   - org.apache.cassandra.service.CassandraDaemon
 {{ range .ExtraArgs }}  - {{ . }}
 {{ end }}

--- a/conf/sproks/cqlsh.yaml
+++ b/conf/sproks/cqlsh.yaml
@@ -1,4 +1,4 @@
-chdir: /data
+chdir: {{ .DataDir }}
 uid: 1337
 gid: 1337
 argv:

--- a/conf/sproks/nodetool.yaml
+++ b/conf/sproks/nodetool.yaml
@@ -1,13 +1,13 @@
-chdir: /data
+chdir: {{ .DataDir }}
 uid: 1337
 gid: 1337
 argv:
   - /usr/bin/java
   - -Xmx128m
   - -Dlogback.configurationFile=logback-tools.xml
-  - -Dstorage-config=/data/conf
+  - -Dstorage-config={{ .ConfDir }}
   - -cp
-  - {{ glob ":" "/data/conf" "/data/lib" "/opt/cassandra/lib/*.jar" }}
+  - {{ glob ":" .ConfDir .LibDir "/opt/cassandra/lib/*.jar" }}
   - org.apache.cassandra.tools.NodeTool
   - -p
   - {{ .JmxPort }}


### PR DESCRIPTION
Replace some hardcoding in the sprok templates with parameters.  I also added a ``LibDir`` parameter because generating it in the templates involved a lot of fugly duplicated code.