### PR TITLE
Added support for specifying datacenter and rack

### DIFF
--- a/conf/cassandra-rackdc.properties
+++ b/conf/cassandra-rackdc.properties
@@ -1,0 +1,20 @@
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These properties are used with GossipingPropertyFileSnitch and will
+# indicate the rack and dc for this node
+dc={{ .DataCenter }}
+rack={{ .Rack }}
+
+# Add a suffix to a datacenter name. Used by the Ec2Snitch and Ec2MultiRegionSnitch
+# to append a string to the EC2 region name.
+#dc_suffix=
+
+# Uncomment the following line to make this snitch prefer the internal ip when possible, as the Ec2MultiRegionSnitch does.
+# prefer_local=true

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -649,7 +649,7 @@ cross_node_timeout: false
 #
 # You can use a custom Snitch by setting this to the full class name
 # of the snitch, which will be assumed to be on your classpath.
-endpoint_snitch: SimpleSnitch
+endpoint_snitch: {{ .Snitch }}
 
 # controls how often to perform the more expensive part of host score
 # calculation


### PR DESCRIPTION
This allows the datacenter, rack (and also snitch) to be passed in as parameters.  For example, these three commands:

```
ID=$(docker run --name=node1 -d -p 9042:9042 pofallon/cassandra -dc "DC1" -rack "RAC1")
docker run --name=node2 -d -p 9043:9042 pofallon/cassandra -dc "DC1" -rack "RAC2" -seeds $IP
docker run --name=node3 -d -p 9044:9042 pofallon/cassandra -dc "DC2" -rack "RAC1" -seeds $IP
```

will create a cluster like the following:

```
$ docker exec -it node1 nodetool status
Datacenter: DC2
===============
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address      Load       Tokens  Owns (effective)  Host ID                               Rack
UN  172.17.0.58  14.34 KB   256     63.9%             a456ce6a-eb03-4529-9636-dc89c829729c  RAC1
Datacenter: DC1
===============
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address      Load       Tokens  Owns (effective)  Host ID                               Rack
UN  172.17.0.56  65.71 KB   256     65.9%             6a73db3c-5ee4-4f4d-acb5-58e3802c22fa  RAC2
UN  172.17.0.55  51.29 KB   256     70.3%             99a34449-217a-48d7-98c8-dca0bf5ef716  RAC1
```
(pofallon/cassandra is just what I called my local build)

In theory you can also pass in `-snitch`, but I'm really just using that parameter internally to override the default in case `-dc` or `-rack` are set (but that could be helpful in an AWS scenario, etc. -- not sure).

Thanks!