### PR TITLE
cassandra optimization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN /bin/sh /install-ubuntu-packages.sh
 # TEMPORARY: while the mirrors are messed up and I'm doing
 # dev passes, this will expect a tarball in the root of the repo
 # wget http://www.apache.dist/cassandra/2.1.3/apache-cassandra-2.1.3-bin.tar.gz
-COPY apache-cassandra-2.1.3-bin.tar.gz /
+#COPY apache-cassandra-2.1.4-bin.tar.gz /
 
 COPY install-cassandra-tarball.sh /
 RUN /bin/sh /install-cassandra-tarball.sh

--- a/install-cassandra-tarball.sh
+++ b/install-cassandra-tarball.sh
@@ -15,10 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION="2.1.3"
-SHA1="306c3bc209717c19f6458a01f2da84f69b974c0f"
+VERSION="2.1.6"
+SHA1="b3f2af56d013301c3e785cc9a46ed668562888df"
 TARBALL="apache-cassandra-${VERSION}-bin.tar.gz"
-URL="http://www.apache.dist/cassandra/${VERSION}/${TARBALL}"
+URL="http://www.apache.org/dist/cassandra/${VERSION}/${TARBALL}"
 
 cd /
 
@@ -34,7 +34,7 @@ echo "${SHA1} ${TARBALL}" > ${TARBALL}.sha1
 ls -l
 
 # copy in from the Dockerfile for now to save downloads
-#curl -O -s ${URL}
+curl -O -s ${URL}
 
 sha1sum --check ${TARBALL}.sha1
 

--- a/install-ubuntu-packages.sh
+++ b/install-ubuntu-packages.sh
@@ -21,9 +21,17 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
+apt-get install -y software-properties-common
 apt-get -y -o Dpkg::Options::='--force-confold' dist-upgrade
 apt-get clean
-apt-get install -y curl busybox openjdk-7-jre-headless java-common libjna-java python
+# install oracle java from PPA
+add-apt-repository ppa:webupd8team/java -y
+apt-get update
+echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+apt-get -y install oracle-java8-set-default && apt-get clean
+update-java-alternatives -s java-8-oracle
+echo "export JAVA_HOME=/usr/lib/jvm/java-8-oracle" >> ~/.bashrc
+apt-get install -y curl busybox python
 apt-get clean
 
 rm -f $0


### PR DESCRIPTION
- replace openjdk 7 with oracle java 8
- install cassandra 2.1.6
